### PR TITLE
Add property textClassName

### DIFF
--- a/src/CopyText/CopyText.test.tsx
+++ b/src/CopyText/CopyText.test.tsx
@@ -57,6 +57,11 @@ describe("CopyText", () => {
     expect(screen.getByText("Copied!")).toBeInTheDocument();
   });
 
+  it("should apply textClassName to the text element", () => {
+    render(<CopyText text="Hello" textClassName="custom-text" />);
+    expect(screen.getByText("Hello")).toHaveClass("custom-text");
+  });
+
   describe("behavior", () => {
     it("should copy the text when the button is clicked", async () => {
       render(<CopyText text="Let's copy text" />);

--- a/src/CopyText/CopyText.tsx
+++ b/src/CopyText/CopyText.tsx
@@ -12,6 +12,7 @@ type CopyTextProps = {
   copied?: boolean;
   onClick?: () => void;
   text: string;
+  textClassName?: string;
 };
 
 const CopyText = ({
@@ -23,6 +24,7 @@ const CopyText = ({
   showIcon = true,
   copiedButtonLabel = "Copied",
   copyButtonLabel = "Copy",
+  textClassName,
 }: CopyTextProps) => {
   const copyText = async () => {
     await navigator.clipboard.writeText(text);
@@ -31,7 +33,7 @@ const CopyText = ({
 
   return (
     <span className={cx(styles.wrapper, className)}>
-      {text}
+      <span className={textClassName}>{text}</span>
       <button className={cx(styles.button, buttonClassName)} onClick={copyText}>
         {copied ? (
           <>


### PR DESCRIPTION
This PR adds the property `textClassName` so the user can style the text that can be copied in the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added optional `textClassName` prop to `CopyText` component for custom text styling
	- Enables more flexible visual customization of copied text display
- **Tests**
	- Added a test case to verify that the `textClassName` prop is correctly applied to the text element in the `CopyText` component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->