### PR TITLE
Custom icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ const [copied, setCopied] = useState(false);
 
 ### With Custom Icons
 
+> Note: You can use icons from any package. This example uses Feather icons (`react-icons/fi`),
+> while the default icons come from Font Awesome (`react-icons/fa6`).
+
 ```jsx
 import { FiCopy, FiCheck } from "react-icons/fi";
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://github.com/user-attachments/assets/a5882c1a-441e-4c6a-acb4-f0b611aaca58
   - [Without Icons](#without-icons)
   - [With Custom Styling](#with-custom-styling)
   - [With Copy Feedback](#with-copy-feedback)
+  - [With Custom Icons](#with-custom-icons)
 - [Installation](#installation)
 - [Usage](#usage)
 - [Props](#props)
@@ -73,6 +74,14 @@ const [copied, setCopied] = useState(false);
 />;
 ```
 
+### With Custom Icons
+
+```jsx
+import { FiCopy, FiCheck } from "react-icons/fi";
+
+<CopyText text="Copy this text" copyIcon={FiCopy} copiedIcon={FiCheck} />;
+```
+
 A simple and customizable React component for copying text to the clipboard.
 
 ## Installation
@@ -109,17 +118,19 @@ function App() {
 
 ## Props
 
-| Prop                | Type     | Default    | Description                                   |
-| ------------------- | -------- | ---------- | --------------------------------------------- |
-| `text`              | string   | (required) | The text to be copied                         |
-| `copied`            | boolean  | `false`    | Indicates if the text has been copied         |
-| `onClick`           | function | `() => {}` | Callback function called after text is copied |
-| `buttonClassName`   | string   | -          | Additional CSS class for the button           |
-| `className`         | string   | -          | Additional CSS class for the wrapper          |
-| `textClassName`     | string   | -          | Additional CSS class for the text element     |
-| `showIcon`          | boolean  | `true`     | Whether to show copy/copied icons             |
-| `copyButtonLabel`   | string   | "Copy"     | Label for the copy button                     |
-| `copiedButtonLabel` | string   | "Copied"   | Label for the copied state                    |
+| Prop                | Type              | Default        | Description                                   |
+| ------------------- | ----------------- | -------------- | --------------------------------------------- |
+| `text`              | string            | (required)     | The text to be copied                         |
+| `copied`            | boolean           | `false`        | Indicates if the text has been copied         |
+| `onClick`           | function          | `() => {}`     | Callback function called after text is copied |
+| `buttonClassName`   | string            | -              | Additional CSS class for the button           |
+| `className`         | string            | -              | Additional CSS class for the wrapper          |
+| `textClassName`     | string            | -              | Additional CSS class for the text element     |
+| `showIcon`          | boolean           | `true`         | Whether to show copy/copied icons             |
+| `copyButtonLabel`   | string            | "Copy"         | Label for the copy button                     |
+| `copiedButtonLabel` | string            | "Copied"       | Label for the copied state                    |
+| `copyIcon`          | React.ElementType | FaRegClipboard | Custom icon for copy state                    |
+| `copiedIcon`        | React.ElementType | FaCheck        | Custom icon for copied state                  |
 
 ## Features
 

--- a/src/CopyText/CopyText.test.tsx
+++ b/src/CopyText/CopyText.test.tsx
@@ -62,6 +62,36 @@ describe("CopyText", () => {
     expect(screen.getByText("Hello")).toHaveClass("custom-text");
   });
 
+  it("should render custom copyIcon when provided", () => {
+    const CustomIcon = () => <span data-testid="custom-copy-icon">Custom</span>;
+    render(<CopyText text="Hello" copyIcon={CustomIcon} />);
+    expect(screen.getByTestId("custom-copy-icon")).toBeInTheDocument();
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+  });
+
+  it("should render custom copiedIcon when provided and copied is true", () => {
+    const CustomIcon = () => (
+      <span data-testid="custom-copied-icon">Custom</span>
+    );
+    render(<CopyText text="Hello" copiedIcon={CustomIcon} copied />);
+    expect(screen.getByTestId("custom-copied-icon")).toBeInTheDocument();
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+  });
+
+  it("should not render custom icons when showIcon is false", () => {
+    const CustomIcon = () => <span data-testid="custom-icon">Custom</span>;
+    render(
+      <CopyText
+        text="Hello"
+        copyIcon={CustomIcon}
+        copiedIcon={CustomIcon}
+        showIcon={false}
+      />
+    );
+    expect(screen.queryByTestId("custom-icon")).not.toBeInTheDocument();
+    expect(screen.queryByText("Custom")).not.toBeInTheDocument();
+  });
+
   describe("behavior", () => {
     it("should copy the text when the button is clicked", async () => {
       render(<CopyText text="Let's copy text" />);

--- a/src/CopyText/CopyText.tsx
+++ b/src/CopyText/CopyText.tsx
@@ -13,6 +13,8 @@ type CopyTextProps = {
   onClick?: () => void;
   text: string;
   textClassName?: string;
+  copyIcon?: React.ElementType;
+  copiedIcon?: React.ElementType;
 };
 
 const CopyText = ({
@@ -25,11 +27,15 @@ const CopyText = ({
   copiedButtonLabel = "Copied",
   copyButtonLabel = "Copy",
   textClassName,
+  copyIcon,
+  copiedIcon,
 }: CopyTextProps) => {
   const copyText = async () => {
     await navigator.clipboard.writeText(text);
     onClick();
   };
+  const CopyIcon = copyIcon || FaRegClipboard;
+  const CopiedIcon = copiedIcon || FaCheck;
 
   return (
     <span className={cx(styles.wrapper, className)}>
@@ -37,12 +43,12 @@ const CopyText = ({
       <button className={cx(styles.button, buttonClassName)} onClick={copyText}>
         {copied ? (
           <>
-            {showIcon && <FaCheck data-testid="copied-icon" />}
+            {showIcon && <CopiedIcon data-testid="copied-icon" />}
             {copiedButtonLabel}
           </>
         ) : (
           <>
-            {showIcon && <FaRegClipboard data-testid="copy-icon" />}
+            {showIcon && <CopyIcon data-testid="copy-icon" />}
             {copyButtonLabel}
           </>
         )}


### PR DESCRIPTION
This PR adds the feature for the user to add custom icons for each state (copy and copied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for custom icons in the `CopyText` component.
  - Users can now customize copy and copied state icons.

- **Documentation**
  - Updated README with examples of using custom icons.
  - Added documentation for new `copyIcon` and `copiedIcon` props.

- **Tests**
  - Expanded test coverage for custom icon functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->